### PR TITLE
Update plot_cm.py

### DIFF
--- a/netplotbrain/plotting/plot_cm.py
+++ b/netplotbrain/plotting/plot_cm.py
@@ -85,14 +85,16 @@ def _plot_connectivitymatrix(ax, edges, nodes=None, node_color=None, node_colorb
             segments_y  = np.concatenate([points_y[:-1], points_y[1:]], axis=1)
             lc_x = LineCollection   (segments_x,
                                     colors      = node_color[nodeorder],
-                                    linewidth   = cm_borderwidth,
+                                    linewidth   = cm_borderwidth*2,
                                     transform   = tr,
-                                    clip_on     = True)
+                                    clip_on     = False,
+                                    zorder      = -1)
             lc_y = LineCollection   (segments_y,
                                     colors      = node_color[nodeorder],
-                                    linewidth   = cm_borderwidth,
+                                    linewidth   = cm_borderwidth*2,
                                     transform   = tr,
-                                    clip_on     = True)
+                                    clip_on     = False,
+                                    zorder      = -1)
             ax.add_collection(lc_x)
             ax.add_collection(lc_y)
 


### PR DESCRIPTION
Currently, the network border, illustrated through LineCollection, is drawn atop of the connectivity/adjacency matrix, due to higher zorder. The clip_on feature limits the LineCollection to be plotted within the plot border, so currently the network border cannot expand outside the matrix. 

I have put clip_on on False, so that the border can expand "out" of the matrix. I put zorder at -1, so it will be drawn underneath the matrices, and doubled the linewidth as half of the line will be covered by the matrix.